### PR TITLE
Permission denied errors under Docker, fix #11

### DIFF
--- a/app/entrusted_client/Cargo.toml
+++ b/app/entrusted_client/Cargo.toml
@@ -26,6 +26,7 @@ toml = "0.5.9"
 fltk = { version = "1.3.16", features = ["fltk-bundled"], optional = true }
 minreq = { version = "2.6.0", features = ["json-using-serde", "https"] }
 semver = "1.0.13"
+libc = "0.2.137"
 entrusted_l10n = { path = "../entrusted_l10n" }
 
 [features]

--- a/docs/TODO.org
+++ b/docs/TODO.org
@@ -6,10 +6,10 @@
   - [ ] Investigate alternate sandbox approaches
   - [ ] Revisit container security options and practices as part of continuous improvement
   - [-] Provide custom container security profile
-    - [ ] Generate [[https://docs.docker.com/engine/security/seccomp/][seccomp]] file (doesn't work on arm64 yet...)
-    - [-] Test on =amd64= machines
-      - [X] Linux
-      - [X] Mac OS
+    - [ ] Generate [[https://docs.docker.com/engine/security/seccomp/][seccomp]] file (doesn't work on arm64 yet, test all supported container solutions too...)
+    - [ ] Test on =amd64= machines
+      - [ ] Linux
+      - [ ] Mac OS
       - [ ] Windows
     - [X] Test on =arm64= (Alpine Linux virtual machine, =entrusted-cli= testing only)
 - [ ] User interface


### PR DESCRIPTION
Permission denied errors under Linux with Docker at the end of conversions 
- Set folder permissions for everybody on the temporary folder used by the program
- This leverages the libc crate and is invoked for non-Windows platforms (Linux and Mac OS)