### PR TITLE
Add gVisor support #36

### DIFF
--- a/.github/workflows/livecd.yml
+++ b/.github/workflows/livecd.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Build live CD
       shell: bash
       run: |
-        "${{ env.entrusted_scripts_dir }}"/01-pre-chroot.sh  "${{ env.entrusted_version }}" "${{ env.entrusted_cpu_arch }}" "${{ env.entrusted_container_arch }}" "${{ env.entrusted_linux_artifacts_dir }}" "${{ env.entrusted_live_boot_dir }}" "${{ env.entrusted_live_boot_tmpdir }}" "${{ env.entrusted_livecd_user_name }}" "${{ env.entrusted_livecd_user_id }}" 
+        "${{ env.entrusted_scripts_dir }}"/01-pre-chroot.sh  "${{ env.entrusted_version }}" "x86_64" "${{ env.entrusted_cpu_arch }}" "${{ env.entrusted_container_arch }}" "${{ env.entrusted_linux_artifacts_dir }}" "${{ env.entrusted_live_boot_dir }}" "${{ env.entrusted_live_boot_tmpdir }}" "${{ env.entrusted_livecd_user_name }}" "${{ env.entrusted_livecd_user_id }}" 
         "${{ env.entrusted_scripts_dir }}"/02-just-chroot.sh "${{ env.entrusted_live_boot_dir }}" "${{ env.entrusted_live_boot_tmpdir }}" "${{ env.entrusted_version }}" "${{ env.entrusted_cpu_arch }}" "${{ env.entrusted_livecd_user_name }}" "${{ env.entrusted_livecd_user_id }}" 
         "${{ env.entrusted_scripts_dir }}"/04-post-chroot.sh "${{ env.entrusted_cpu_arch }}" "${{ env.entrusted_live_boot_dir }}" "${{ env.entrusted_live_iso_dir }}" 
     - name: Upload portable installation
@@ -124,7 +124,7 @@ jobs:
     - name: Build live CD
       shell: bash
       run: |
-        "${{ env.entrusted_scripts_dir }}"/01-pre-chroot.sh  "${{ env.entrusted_version }}" "${{ env.entrusted_cpu_arch }}" "${{ env.entrusted_container_arch }}" "${{ env.entrusted_linux_artifacts_dir }}" "${{ env.entrusted_live_boot_dir }}" "${{ env.entrusted_live_boot_tmpdir }}" "${{ env.entrusted_livecd_user_name }}" "${{ env.entrusted_livecd_user_id }}" 
+        "${{ env.entrusted_scripts_dir }}"/01-pre-chroot.sh  "${{ env.entrusted_version }}" "aarch64" "${{ env.entrusted_cpu_arch }}" "${{ env.entrusted_container_arch }}" "${{ env.entrusted_linux_artifacts_dir }}" "${{ env.entrusted_live_boot_dir }}" "${{ env.entrusted_live_boot_tmpdir }}" "${{ env.entrusted_livecd_user_name }}" "${{ env.entrusted_livecd_user_id }}" 
         "${{ env.entrusted_scripts_dir }}"/02-just-chroot.sh "${{ env.entrusted_live_boot_dir }}" "${{ env.entrusted_live_boot_tmpdir }}" "${{ env.entrusted_version }}" "${{ env.entrusted_cpu_arch }}" "${{ env.entrusted_livecd_user_name }}" "${{ env.entrusted_livecd_user_id }}" 
         "${{ env.entrusted_scripts_dir }}"/04-post-chroot.sh "${{ env.entrusted_cpu_arch }}" "${{ env.entrusted_live_boot_dir }}" "${{ env.entrusted_live_iso_dir }}" 
     - name: Upload portable installation

--- a/app/entrusted_client/src/container.rs
+++ b/app/entrusted_client/src/container.rs
@@ -326,7 +326,7 @@ pub fn convert(input_path: PathBuf, output_path: PathBuf, convert_options: commo
             let _ = unsafe { libc::chmod (path_safe, 0o777) };
         }
 
-        let safedir_volume = format!("{}:/safezone:Z", dz_tmp_safe.display());
+        let safedir_volume = format!("{}:/entrusted:Z", dz_tmp_safe.display());
 
         // TODO make Lima handling more explicit but less annoying, abstractions?
         // Need to ensure that we use /tmp/lima for Lima as other folders are not mounted by default...

--- a/app/entrusted_container/Dockerfile
+++ b/app/entrusted_container/Dockerfile
@@ -84,4 +84,4 @@ ENV ENTRUSTED_TESSERACT_TESSDATA_DIR  /usr/share/tesseract-ocr/4.00/tessdata
 # /tmp/input_file is where the first convert expects the input file to be, and /tmp where it will write the pixel files
 #
 # /safezone is where the wrapper eventually moves the sanitized files.
-VOLUME /safezone
+VOLUME /entrusted

--- a/app/entrusted_container/src/main.rs
+++ b/app/entrusted_container/src/main.rs
@@ -113,7 +113,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let raw_input_path   = Path::new("/tmp/input_file");
         let output_file_path = Path::new("/tmp/safe-output-compressed.pdf");
         let output_dir_path  = Path::new("/tmp/");
-        let safe_dir_path    = Path::new("/safezone/safe-output-compressed.pdf");
+        let safe_dir_path    = Path::new("/entrusted/safe-output-compressed.pdf");
 
         // step 1 (0%-20%)
         let mut progress_range = ProgressRange::new(0, 20);

--- a/ci_cd/README.org
+++ b/ci_cd/README.org
@@ -1,10 +1,10 @@
 #+TITLE: entrusted/ci_cd
-
- Except for the the live CD, release artifacts are produced from a containerized environment ([[https://podman.io/][Podman]]).
-
+ 
 * Overview
 
-The current build server is a virtual machine running [[https://ubuntu.com/][Ubuntu Linux]].
+It is possible to produce all release artifacts using GitHub Actions or locally.
+
+The local build server is a virtual machine running [[https://ubuntu.com/][Ubuntu Linux]].
 
   [[./images/cicd.png]]
 
@@ -37,19 +37,3 @@ There's no support yet for creating arm64 Windows binaries. The installer is bui
 For the "app bundle", there might be better ways to run external programs (i.e. instead of wrapping programs with a shell script)
 - https://developer.apple.com/documentation/xcode/embedding-a-helper-tool-in-a-sandboxed-app
 - https://stackoverflow.com/questions/27505022/open-another-mac-app
-
-  
-* Future Work
-
- =GitHub actions=, =TravisCI= or other similar solutions are ideal.
-
-Pros:
- - It is generally good to leverage free hosted solutions
- - It will help with build times ahead of releases
- - It will save local disk space and computing resources
-
-Cons:
- - It might impact releases flexibility (i.e. arm64 support)
- - It will require learning (or re-learning) infrastructure specific ecosystem (pipelines, tools, constraints, etc.)
-
-Pull requests are welcome for any improvements!

--- a/ci_cd/linux/build.sh
+++ b/ci_cd/linux/build.sh
@@ -4,7 +4,7 @@ set -x
 PREVIOUSDIR="$(echo $PWD)"
 SCRIPTDIR="$(realpath $(dirname "$0"))"
 PROJECTDIR="$(realpath ${SCRIPTDIR}/../../app)"
-APPVERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' ${PROJECTDIR}/entrusted_client/Cargo.toml)
+APPVERSION=$(grep "^version" ${PROJECTDIR}/entrusted_client/Cargo.toml  | cut -d"=" -f2 | xargs)
 CPU_ARCHS="amd64 aarch64"
 
 for CPU_ARCH in ${CPU_ARCHS} ; do

--- a/ci_cd/live_cd/02-just-chroot.sh
+++ b/ci_cd/live_cd/02-just-chroot.sh
@@ -13,7 +13,9 @@ ROOT_SCRIPTS_DIR="$(realpath $(dirname "$0"))"
 sudo cp -rf "${ROOT_SCRIPTS_DIR}"/chroot_files "${LIVE_BOOT_DIR}"/chroot/files
 sudo cp -rf "${ROOT_SCRIPTS_DIR}"/03-in-chroot.sh "${LIVE_BOOT_DIR}"/chroot/files/
 sudo cp "${LIVE_BOOT_TMP_DIR}"/live-libhardened_malloc.so "${LIVE_BOOT_DIR}"/chroot/files/libhardened_malloc.so
-
+# sudo cp -r "${LIVE_BOOT_TMP_DIR}"/minikernel "${LIVE_BOOT_DIR}"/chroot/files/minikernel
+sudo cp -r "${LIVE_BOOT_TMP_DIR}"/podman "${LIVE_BOOT_DIR}"/chroot/files/podman
+sudo cp -r "${LIVE_BOOT_TMP_DIR}"/gvisor "${LIVE_BOOT_DIR}"/chroot/files/gvisor
 sudo mv "${LIVE_BOOT_TMP_DIR}"/entrusted-packaging "${LIVE_BOOT_DIR}"/chroot/files/entrusted-packaging
 sudo mv "${LIVE_BOOT_TMP_DIR}"/live-entrusted-cli "${LIVE_BOOT_DIR}"/chroot/files/entrusted-cli
 sudo mv "${LIVE_BOOT_TMP_DIR}"/live-entrusted-webserver "${LIVE_BOOT_DIR}"/chroot/files/entrusted-webserver

--- a/ci_cd/live_cd/build.sh
+++ b/ci_cd/live_cd/build.sh
@@ -46,6 +46,7 @@ for CPU_ARCH in $CPU_ARCHS ; do
     LINUX_ARTIFACTSDIR="${ENTRUSTED_ROOT_TMPDIR}/entrusted-livecd/linux_artifacts-${CPU_ARCH}-${ENTRUSTED_VERSION}"
     LIVE_ISO_DIR="${PROJECTDIR}/../artifacts"
     DEBIAN_ARCH="amd64"
+    UNAME_ARCH="x86_64"
     RUST_MUSL_TARGET="x86_64-unknown-linux-musl"
     RUST_PREAMBLE="RUSTFLAGS='-C target-feature=+crt-static'"
     test -d "${ENTRUSTED_ROOT_TMPDIR}" && sudo rm -rf "${ENTRUSTED_ROOT_TMPDIR}"
@@ -56,6 +57,7 @@ for CPU_ARCH in $CPU_ARCHS ; do
     if [ ${CPU_ARCH} != "amd64" ]
     then
         DEBIAN_ARCH="arm64"
+        UNAME_ARCH="aarch64"
         RUST_MUSL_TARGET="aarch64-unknown-linux-musl"
         RUST_PREAMBLE="CC_AARCH64_UNKNOWN_LINUX_MUSL=musl-gcc CXX_AARCH64_UNKNOWN_LINUX_MUSL=musl-g++ AR_AARCH64_UNKNOWN_LINUX_MUSL=ar CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc RUSTFLAGS='-C link-arg=-lgcc -C target-feature=+crt-static'"
     fi        
@@ -74,7 +76,7 @@ for CPU_ARCH in $CPU_ARCHS ; do
     ROOT_SCRIPTS_DIR="$(realpath $(dirname "$0"))"
     chmod +x "${ROOT_SCRIPTS_DIR}"/*.sh
 
-    "${ROOT_SCRIPTS_DIR}"/01-pre-chroot.sh "${ENTRUSTED_VERSION}" "${DEBIAN_ARCH}" "${DEBIAN_ARCH}" "${LINUX_ARTIFACTSDIR}" "${LIVE_BOOT_DIR}" "${LIVE_BOOT_TMP_DIR}" "${CONTAINER_USER_NAME}" "${CONTAINER_USER_ID}"
+    "${ROOT_SCRIPTS_DIR}"/01-pre-chroot.sh "${ENTRUSTED_VERSION}" "${UNAME_ARCH}" "${DEBIAN_ARCH}" "${DEBIAN_ARCH}" "${LINUX_ARTIFACTSDIR}" "${LIVE_BOOT_DIR}" "${LIVE_BOOT_TMP_DIR}" "${CONTAINER_USER_NAME}" "${CONTAINER_USER_ID}"
     retVal=$?
     if [ $retVal -ne 0 ]; then
         echo "Failed to prepare build for ${CPU_ARCH}"

--- a/ci_cd/live_cd/chroot_files/etc/systemd/system/entrusted-init.service
+++ b/ci_cd/live_cd/chroot_files/etc/systemd/system/entrusted-init.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Entrusted Init Service
+After=systemd-user-sessions.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/entrusted-init
+RemainAfterExit=yes
+
+[Install]
+WantedBy=default.target
+

--- a/ci_cd/live_cd/chroot_files/etc/systemd/system/entrusted-webserver.service
+++ b/ci_cd/live_cd/chroot_files/etc/systemd/system/entrusted-webserver.service
@@ -1,16 +1,18 @@
 [Unit]
 Description=Entrusted Web Server
-After=systemd-user-sessions.service
+After=entrusted-init.service
 
 [Service]
 Environment=LD_PRELOAD=/usr/lib/libhardened_malloc.so
-Environment=ENTRUSTED_AUTOMATED_SECCOMP_ENABLEMENT=true
+Environment=ENTRUSTED_AUTOMATED_SECCOMP_ENABLEMENT=false
+Environment=ENTRUSTED_AUTOMATED_GVISOR_ENABLEMENT=true
 Type=simple
 User=entrusted
-ExecStart=/usr/local/bin/entrusted-webserver --host 0.0.0.0 --port 13000
+ExecStart=bash -l -c "/usr/local/bin/entrusted-webserver --host 0.0.0.0 --port 13000"
 StandardOutput=file:/var/log/entrusted-webserver/stdout.log
 StandardError=file:/var/log/entrusted-webserver/stderr.log
 Restart=always
+PrivateIPC=true
 Capabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_DAC_OVERRIDE CAP_AUDIT_WRITE
 
 [Install]

--- a/ci_cd/live_cd/chroot_files/home/entrusted/.bash_profile
+++ b/ci_cd/live_cd/chroot_files/home/entrusted/.bash_profile
@@ -1,0 +1,3 @@
+export XDG_RUNTIME_DIR=/run/user/$(id -u)
+export RUNLEVEL=3
+export PATH="${PATH}:/sbin"

--- a/ci_cd/live_cd/chroot_files/home/entrusted/.config/containers/containers.conf
+++ b/ci_cd/live_cd/chroot_files/home/entrusted/.config/containers/containers.conf
@@ -1,2 +1,5 @@
 [engine]
-cgroup_manager = "cgroupfs"
+runtime = "runsc"
+
+[engine.runtimes]
+runsc = ["/usr/local/bin/runsc-podman"]

--- a/ci_cd/live_cd/chroot_files/usr/local/bin/entrusted-init
+++ b/ci_cd/live_cd/chroot_files/usr/local/bin/entrusted-init
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+loginctl enable-linger entrusted
+runuser -l entrusted -c "systemctl --user start dbus"

--- a/ci_cd/live_cd/chroot_files/usr/local/bin/runsc-podman
+++ b/ci_cd/live_cd/chroot_files/usr/local/bin/runsc-podman
@@ -1,0 +1,2 @@
+#!/bin/bash
+runsc --ignore-cgroups --network none --TESTONLY-unsafe-nonroot "$@"

--- a/ci_cd/live_cd/post_chroot_files/home/entrusted/LIVE_BOOT/staging/boot/grub/grub.cfg
+++ b/ci_cd/live_cd/post_chroot_files/home/entrusted/LIVE_BOOT/staging/boot/grub/grub.cfg
@@ -4,11 +4,11 @@ set default="0"
 set timeout=2
 
 menuentry "Entrusted Live [EFI/GRUB]" {
-    linux ($root)/live/vmlinuz boot=live notsc slab_nomerge init_on_alloc=1 init_on_free=1 page_alloc.shuffle=1 randomize_kstack_offset=on debugfs=off ipv6.disable=1 clocksource=acpi_pm acpi=force apm=power_off ramdisk-size=75% overlay-size=75%
+    linux ($root)/live/vmlinuz boot=live notsc slab_nomerge init_on_alloc=1 init_on_free=1 page_alloc.shuffle=1 randomize_kstack_offset=on debugfs=off ipv6.disable=1 clocksource=acpi_pm acpi=force apm=power_off ramdisk-size=75% overlay-size=75% trace_clock=global
     initrd ($root)/live/initrd
 }
 
 menuentry "Entrusted Live [EFI/GRUB] (nomodeset)" {
-    linux ($root)/live/vmlinuz boot=live notsc slab_nomerge init_on_alloc=1 init_on_free=1 page_alloc.shuffle=1 randomize_kstack_offset=on debugfs=off ipv6.disable=1 clocksource=acpi_pm acpi=force apm=power_off ramdisk-size=75% overlay-size=75% nomodeset
+    linux ($root)/live/vmlinuz boot=live notsc slab_nomerge init_on_alloc=1 init_on_free=1 page_alloc.shuffle=1 randomize_kstack_offset=on debugfs=off ipv6.disable=1 clocksource=acpi_pm acpi=force apm=power_off ramdisk-size=75% overlay-size=75% trace_clock=global nomodeset
     initrd ($root)/live/initrd
 }

--- a/ci_cd/live_cd/post_chroot_files/home/entrusted/LIVE_BOOT/staging/isolinux/isolinux.cfg
+++ b/ci_cd/live_cd/post_chroot_files/home/entrusted/LIVE_BOOT/staging/isolinux/isolinux.cfg
@@ -19,10 +19,10 @@ LABEL linux
   MENU LABEL Entrusted Live [BIOS/ISOLINUX]
   MENU DEFAULT
   KERNEL /live/vmlinuz
-  APPEND initrd=/live/initrd boot=live notsc slab_nomerge init_on_alloc=1 init_on_free=1 page_alloc.shuffle=1 randomize_kstack_offset=on debugfs=off ipv6.disable=1 clocksource=acpi_pm acpi=force apm=power_off ramdisk-size=75% overlay-size=75%
+  APPEND initrd=/live/initrd boot=live notsc slab_nomerge init_on_alloc=1 init_on_free=1 page_alloc.shuffle=1 randomize_kstack_offset=on debugfs=off ipv6.disable=1 clocksource=acpi_pm acpi=force apm=power_off ramdisk-size=75% overlay-size=75% trace_clock=global
 
 LABEL linux
   MENU LABEL Entrusted Live [BIOS/ISOLINUX] (nomodeset)
   MENU DEFAULT
   KERNEL /live/vmlinuz
-  APPEND initrd=/live/initrd boot=live notsc slab_nomerge init_on_alloc=1 init_on_free=1 page_alloc.shuffle=1 randomize_kstack_offset=on debugfs=off ipv6.disable=1 clocksource=acpi_pm acpi=force apm=power_off ramdisk-size=75% overlay-size=75% nomodeset 
+  APPEND initrd=/live/initrd boot=live notsc slab_nomerge init_on_alloc=1 init_on_free=1 page_alloc.shuffle=1 randomize_kstack_offset=on debugfs=off ipv6.disable=1 clocksource=acpi_pm acpi=force apm=power_off ramdisk-size=75% overlay-size=75% trace_clock=global nomodeset 

--- a/ci_cd/macos/build.sh
+++ b/ci_cd/macos/build.sh
@@ -4,7 +4,7 @@ set -x
 PREVIOUSDIR="$(echo $PWD)"
 SCRIPTDIR="$(realpath $(dirname "$0"))"
 PROJECTDIR="$(realpath ${SCRIPTDIR}/../../app)"
-APPVERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' ${PROJECTDIR}/entrusted_client/Cargo.toml)
+APPVERSION=$(grep "^version" ${PROJECTDIR}/entrusted_client/Cargo.toml  | cut -d"=" -f2 | xargs)
 CPU_ARCHS="amd64 aarch64"
 
 for CPU_ARCH in $CPU_ARCHS ; do

--- a/ci_cd/windows/build.sh
+++ b/ci_cd/windows/build.sh
@@ -4,7 +4,7 @@ set -x
 PREVIOUSDIR="$(echo $PWD)"
 SCRIPTDIR="$(realpath $(dirname "$0"))"
 PROJECTDIR="$(realpath ${SCRIPTDIR}/../../app)"
-APPVERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' ${PROJECTDIR}/entrusted_client/Cargo.toml)
+APPVERSION=$(grep "^version" ${PROJECTDIR}/entrusted_client/Cargo.toml  | cut -d"=" -f2 | xargs)
 ARTIFACTSDIR="${PROJECTDIR}/../artifacts/entrusted-windows-amd64-${APPVERSION}"
 
 mkdir -p ${ARTIFACTSDIR}


### PR DESCRIPTION
- Update GitHub actions workflow for new CPU architecture alias
- Update CI/CD shell scripts
- Change volume name from 'safezone' to 'entrusted' in the container image
- Add gVisor environment variable and specific flags for Live CD mode
- Replace outdated podman debian packages with podman-static
- Replace openssh with dropbear
- Improve application version extraction from shell scripts